### PR TITLE
use current branch as darwin input for flakes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,10 +52,9 @@ jobs:
         export NIX_PATH=$HOME/.nix-defexpr/channels
         nix-shell -A installer
     - run: |
-        nix registry add darwin $PWD
-        nix build ./modules/examples#darwinConfigurations.simple.system
+        nix build ./modules/examples#darwinConfigurations.simple.system --override-input darwin .
     - run: |
-        ./result/sw/bin/darwin-rebuild switch --flake ./modules/examples#simple
+        ./result/sw/bin/darwin-rebuild switch --flake ./modules/examples#simple --override-input darwin .
     - run: |
         . /etc/static/bashrc
-        darwin-rebuild build --flake ./modules/examples#simple
+        darwin-rebuild build --flake ./modules/examples#simple --override-input darwin .


### PR DESCRIPTION
Overriding the registry was supposed to handle this but it seems the behaviour changed at some point or never worked as intended if an url is defined for the input.